### PR TITLE
Added the ability to use a proxy when making requests

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -358,10 +358,10 @@ TwitterClient.prototype._call = function( requestMethod, requestUri, requestArgs
             http.host = this.proxy.host;
             http.path = "https://" + http.hostname + http.path;
             delete http.hostname;
-	}
-	if (typeof this.proxy.port != "undefined") {
-	    http.port = this.proxy.port;
-	}
+        }
+        if (typeof this.proxy.port != "undefined") {
+            http.port = this.proxy.port;
+        }
     }
     var req = require('https').get( http, callback );
     if( timeout ){


### PR DESCRIPTION
I ran into an issue recently where my app had to make outbound requests using a proxy. Without having to make major modifications to your code I added this shim to make it work.

How to use it:
twitterClient.setProxy({host: 'proxy.mysite.com', port: 443});
