### PR TITLE
fix http request: don't use http.get

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -344,8 +344,8 @@ TwitterClient.prototype._call = function( requestMethod, requestUri, requestArgs
         Authorization: authHeader,
         'User-Agent': TWITTER_API_USERAGENT 
     };
+    http.method = requestMethod;
     if( 'POST' === requestMethod ){
-        http.method = 'POST';
         http.headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
         http.headers['Content-Length'] = query.length;
     }
@@ -363,7 +363,7 @@ TwitterClient.prototype._call = function( requestMethod, requestUri, requestArgs
             http.port = this.proxy.port;
         }
     }
-    var req = require('https').get( http, callback );
+    var req = require('https').request( http, callback );
     if( timeout ){
         req.on('socket', function (socket) {
             socket.setTimeout( timeout );  


### PR DESCRIPTION
Don't use http.get since we sometimes use POST method, and always manually call request.end(), which are redundant with http.get(), and maybe conflicting.