### PR TITLE
Set socket KeepAlive, useful for streaming requests

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -364,6 +364,7 @@ TwitterClient.prototype._call = function( requestMethod, requestUri, requestArgs
         }
     }
     var req = require('https').get( http, callback );
+    req.setSocketKeepAlive( true );
     if( timeout ){
         req.on('socket', function (socket) {
             socket.setTimeout( timeout );  


### PR DESCRIPTION
I got long standing client.stream stopping receiving new tweets, this probably helps.
