### PR TITLE
Call a last time the stream callback on stream request end

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -316,6 +316,7 @@ TwitterClient.prototype.stream = function( requestPath, requestArgs, callback ){
         } );
         res.on('end', function(){
             client.response = null;
+            callback( null );
         } );
     } );
 }


### PR DESCRIPTION
There is currently no way to know when the stream has ended: neither the http.request nor http.response is available outside TwitterClient.
By calling with a null argment the client.stream caller can know the stream ended.
