### PR TITLE
Fix headers to conform to tighter node requirements

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -146,7 +146,7 @@ OAuthParams.prototype.getHeader = function(){
         }
     }
     this.args = args;
-    return 'OAuth '+lines.join(',\n ');
+    return 'OAuth '+lines.join(', ');
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "twitter-api",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "license": "MIT",
     "author" : "Tim Whitlock (http://timwhitlock.info)",
     "description" : "Twitter API 1.1 client supporting REST and streaming",


### PR DESCRIPTION
Sending headers with \n in now fails due to node enforcing http compliance more strictly, throwing an exception in _http and killing the app running.

Removing the \n is a safe and simple change.
