### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Twitter API library for NodeJS
 
+[![API Testing](https://img.shields.io/badge/test%20this%20API%20on-RapidAPI.com-blue.svg)](https://rapidapi.com/package/Twitter/functions?utm_source=GithubTwitter&utm_medium=button)
+
 * Supports version 1.1 of Twitter's REST and Streaming APIs
 * See examples directory for usage
 


### PR DESCRIPTION
I've added a link in your README to Twitter's functions page in RapidAPI. I've done this for a few Twitter SDKs to help those who are reading the READMEs, understand and test the API before use.